### PR TITLE
Fix requireconfig js load error

### DIFF
--- a/src/module-attribute-pagination/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/src/module-attribute-pagination/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -127,7 +127,7 @@ $stores = $block->getStoresSortedBySortOrder();
                     "element": "required-dropdown-attribute-unique",
                     "message": "<?= $block->escapeHtml(__("The value of Admin must be unique.")) ?>"
                 },
-                "attributeOptionPager": {
+                "Nanobots_AttributeOptionPager/js/pager": {
                     "ajaxUrlValue": {}
                 }
             }


### PR DESCRIPTION
Fixed requirejs config load error, Magento 2.4.6 CE.