### PR TITLE
Add support for text/visual swatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+* add support for text/visual swatches
+
 ## Version 1.0.2
 * adding sort order field to attribute options
 * adding CHANGELOG.md file

--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ Module should work out-of-the box
 - Magento 2.3.7 Open Source
 - Magento 2.4.2 Open Source
 - Magento 2.4.3 Open Source
+- Magento 2.4.7 Open Source
 
 If there are issues / problems, please open an issue within the repository or submit a pull request.

--- a/src/module-attribute-pagination/Block/Adminhtml/Attribute/Edit/Options/Text.php
+++ b/src/module-attribute-pagination/Block/Adminhtml/Attribute/Edit/Options/Text.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Nanobots\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options;
+
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\Collection;
+use Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text as BaseText;
+/**
+ * Block Class for Text Swatch
+ *
+ * @api
+ * @since 100.0.2
+ */
+class Text extends BaseText
+{
+    /** @var int  */
+    public const DEFAULT_PAGE = 1;
+
+    /** @var int  */
+    public const DEFAULT_LIMIT = 20;
+
+    /** @var int[]  */
+    public const LIMIT = [20, 30, 50, 100, 200];
+
+    /** @var string  */
+    protected $_template = 'Nanobots_AttributeOptionPager::catalog/product/attribute/text.phtml';
+
+    /**
+     * Retrieve option values collection
+     *
+     * It is represented by an array in case of system attribute
+     *
+     * @param AbstractAttribute $attribute
+     * @return array|Collection
+     */
+    protected function _getOptionValuesCollection(AbstractAttribute $attribute)
+    {
+        if ($this->canManageOptionDefaultOnly()) {
+            return $this->_universalFactory->create(
+                $attribute->getSourceModel()
+            )->setAttribute(
+                $attribute
+            )->getAllOptions();
+        } else {
+            return $this->_attrOptionCollectionFactory->create()->setAttributeFilter(
+                $attribute->getId()
+            )->setPositionOrder(
+                'asc',
+                true
+            )->setPageSize($this->getRequest()->getParam('limit') ?? self::DEFAULT_LIMIT)
+                ->setCurPage($this->getRequest()->getParam('page') ?? self::DEFAULT_PAGE)
+                ->load();
+        }
+    }
+
+    /**
+     * Preparing values of attribute options
+     *
+     * @param AbstractAttribute $attribute
+     * @param array|Collection $optionCollection
+     * @return array
+     */
+    protected function _prepareOptionValues(
+        AbstractAttribute $attribute,
+        $optionCollection
+    ): array
+    {
+        $type = $attribute->getFrontendInput();
+        if ($type === 'select' || $type === 'multiselect') {
+            $defaultValues = explode(',', $attribute->getDefaultValue() ?? '');
+            $inputType = $type === 'select' ? 'radio' : 'checkbox';
+        } else {
+            $defaultValues = [];
+            $inputType = '';
+        }
+
+        $values = [];
+        $isSystemAttribute = is_array($optionCollection);
+        if ($isSystemAttribute) {
+            $values = $this->getPreparedValues($optionCollection, $isSystemAttribute, $inputType, $defaultValues);
+        } else {
+            $optionCollection->setPageSize($this->getRequest()->getParam('limit'));
+            $values = array_merge(
+                $values,
+                $this->getPreparedValues($optionCollection, $isSystemAttribute, $inputType, $defaultValues)
+            );
+        }
+
+        return $values;
+    }
+
+
+    /**
+     * @param array|Collection $optionCollection
+     * @param bool $isSystemAttribute
+     * @param string $inputType
+     * @param array $defaultValues
+     * @return array
+     */
+    private function getPreparedValues(
+        $optionCollection,
+        bool $isSystemAttribute,
+        string $inputType,
+        array $defaultValues
+    ): array
+    {
+        $values = [];
+        foreach ($optionCollection as $option) {
+            $bunch = $isSystemAttribute ? $this->_prepareSystemAttributeOptionValues(
+                $option,
+                $inputType,
+                $defaultValues
+            ) : $this->_prepareUserDefinedAttributeOptionValues(
+                $option,
+                $inputType,
+                $defaultValues
+            );
+            foreach ($bunch as $value) {
+                $values[] = new \Magento\Framework\DataObject($value);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array|mixed|null
+     */
+    public function getOptionValues()
+    {
+        $values = $this->_getData('option_values');
+        if ($values === null) {
+            $values = [];
+
+            $attribute = $this->getAttributeObject();
+            $optionCollection = $this->_getOptionValuesCollection($attribute);
+            if ($optionCollection) {
+                $values = $this->_prepareOptionValues($attribute, $optionCollection);
+            }
+
+            $this->setData('option_values', $values);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrentPageNumber(): int
+    {
+        if ($this->getRequest()->getParam('page')) {
+            return (int)$this->getRequest()->getParam('page');
+        }
+        return self::DEFAULT_PAGE;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrentPageSize(): int
+    {
+        if ($this->getRequest()->getParam('limit')) {
+            return (int)$this->getRequest()->getParam('limit');
+        }
+        return self::DEFAULT_LIMIT;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getLimits(): array
+    {
+        return self::LIMIT;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxPageCount(): int
+    {
+        $attribute = $this->getAttributeObject();
+        return $this->_attrOptionCollectionFactory->create()->setAttributeFilter(
+            $attribute->getId()
+        )->setPageSize($this->getRequest()->getParam('limit') ?? self::DEFAULT_LIMIT)
+            ->getLastPageNumber();
+
+    }
+
+    /**
+     * @param int $limit
+     * @param int $pageNumber
+     * @return string
+     */
+    public function getNextUrl(int $limit, int $pageNumber): string
+    {
+        $requestParams = $this->getRequest()->getParams();
+        $requestParams['page'] = $pageNumber;
+        $requestParams['limit'] = $limit;
+        return $this->getUrl('*/*/*', $requestParams);
+    }
+}

--- a/src/module-attribute-pagination/Block/Adminhtml/Attribute/Edit/Options/Visual.php
+++ b/src/module-attribute-pagination/Block/Adminhtml/Attribute/Edit/Options/Visual.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Nanobots\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options;
+
+use Magento\Eav\Model\Entity\Attribute\AbstractAttribute;
+use Magento\Eav\Model\ResourceModel\Entity\Attribute\Option\Collection;
+use Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual as BaseVisual;
+
+/**
+ * Block Class for Visual Swatch
+ *
+ * @api
+ * @since 100.0.2
+ */
+class Visual extends BaseVisual
+{
+    /** @var int  */
+    public const DEFAULT_PAGE = 1;
+
+    /** @var int  */
+    public const DEFAULT_LIMIT = 20;
+
+    /** @var int[]  */
+    public const LIMIT = [20, 30, 50, 100, 200];
+
+    /** @var string  */
+    protected $_template = 'Nanobots_AttributeOptionPager::catalog/product/attribute/visual.phtml';
+
+    /**
+     * Retrieve option values collection
+     *
+     * It is represented by an array in case of system attribute
+     *
+     * @param AbstractAttribute $attribute
+     * @return array|Collection
+     */
+    protected function _getOptionValuesCollection(AbstractAttribute $attribute)
+    {
+        if ($this->canManageOptionDefaultOnly()) {
+            return $this->_universalFactory->create(
+                $attribute->getSourceModel()
+            )->setAttribute(
+                $attribute
+            )->getAllOptions();
+        } else {
+            return $this->_attrOptionCollectionFactory->create()->setAttributeFilter(
+                $attribute->getId()
+            )->setPositionOrder(
+                'asc',
+                true
+            )->setPageSize($this->getRequest()->getParam('limit') ?? self::DEFAULT_LIMIT)
+                ->setCurPage($this->getRequest()->getParam('page') ?? self::DEFAULT_PAGE)
+                ->load();
+        }
+    }
+
+    /**
+     * Preparing values of attribute options
+     *
+     * @param AbstractAttribute $attribute
+     * @param array|Collection $optionCollection
+     * @return array
+     */
+    protected function _prepareOptionValues(
+        AbstractAttribute $attribute,
+        $optionCollection
+    ): array
+    {
+        $type = $attribute->getFrontendInput();
+        if ($type === 'select' || $type === 'multiselect') {
+            $defaultValues = explode(',', $attribute->getDefaultValue() ?? '');
+            $inputType = $type === 'select' ? 'radio' : 'checkbox';
+        } else {
+            $defaultValues = [];
+            $inputType = '';
+        }
+
+        $values = [];
+        $isSystemAttribute = is_array($optionCollection);
+        if ($isSystemAttribute) {
+            $values = $this->getPreparedValues($optionCollection, $isSystemAttribute, $inputType, $defaultValues);
+        } else {
+            $optionCollection->setPageSize($this->getRequest()->getParam('limit'));
+            $values = array_merge(
+                $values,
+                $this->getPreparedValues($optionCollection, $isSystemAttribute, $inputType, $defaultValues)
+            );
+        }
+
+        return $values;
+    }
+
+
+    /**
+     * @param array|Collection $optionCollection
+     * @param bool $isSystemAttribute
+     * @param string $inputType
+     * @param array $defaultValues
+     * @return array
+     */
+    private function getPreparedValues(
+        $optionCollection,
+        bool $isSystemAttribute,
+        string $inputType,
+        array $defaultValues
+    ): array
+    {
+        $values = [];
+        foreach ($optionCollection as $option) {
+            $bunch = $isSystemAttribute ? $this->_prepareSystemAttributeOptionValues(
+                $option,
+                $inputType,
+                $defaultValues
+            ) : $this->_prepareUserDefinedAttributeOptionValues(
+                $option,
+                $inputType,
+                $defaultValues
+            );
+            foreach ($bunch as $value) {
+                $values[] = new \Magento\Framework\DataObject($value);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array|mixed|null
+     */
+    public function getOptionValues()
+    {
+        $values = $this->_getData('option_values');
+        if ($values === null) {
+            $values = [];
+
+            $attribute = $this->getAttributeObject();
+            $optionCollection = $this->_getOptionValuesCollection($attribute);
+            if ($optionCollection) {
+                $values = $this->_prepareOptionValues($attribute, $optionCollection);
+            }
+
+            $this->setData('option_values', $values);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrentPageNumber(): int
+    {
+        if ($this->getRequest()->getParam('page')) {
+            return (int)$this->getRequest()->getParam('page');
+        }
+        return self::DEFAULT_PAGE;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrentPageSize(): int
+    {
+        if ($this->getRequest()->getParam('limit')) {
+            return (int)$this->getRequest()->getParam('limit');
+        }
+        return self::DEFAULT_LIMIT;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getLimits(): array
+    {
+        return self::LIMIT;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxPageCount(): int
+    {
+        $attribute = $this->getAttributeObject();
+        return $this->_attrOptionCollectionFactory->create()->setAttributeFilter(
+            $attribute->getId()
+        )->setPageSize($this->getRequest()->getParam('limit') ?? self::DEFAULT_LIMIT)
+            ->getLastPageNumber();
+
+    }
+
+    /**
+     * @param int $limit
+     * @param int $pageNumber
+     * @return string
+     */
+    public function getNextUrl(int $limit, int $pageNumber): string
+    {
+        $requestParams = $this->getRequest()->getParams();
+        $requestParams['page'] = $pageNumber;
+        $requestParams['limit'] = $limit;
+        return $this->getUrl('*/*/*', $requestParams);
+    }
+}

--- a/src/module-attribute-pagination/etc/di.xml
+++ b/src/module-attribute-pagination/etc/di.xml
@@ -9,6 +9,12 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-	<preference for="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options"
+    <preference for="Magento\Eav\Block\Adminhtml\Attribute\Edit\Options\Options"
 				type="Nanobots\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Options"/>
+
+    <preference for="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Text"
+				type="Nanobots\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Text"/>
+
+    <preference for="Magento\Swatches\Block\Adminhtml\Attribute\Edit\Options\Visual"
+				type="Nanobots\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Visual"/>
 </config>

--- a/src/module-attribute-pagination/etc/module.xml
+++ b/src/module-attribute-pagination/etc/module.xml
@@ -13,6 +13,7 @@
 		<sequence>
 			<module name="Magento_Backend"/>
 			<module name="Magento_Eav"/>
+			<module name="Magento_Swatches"/>
 		</sequence>
 	</module>
 </config>

--- a/src/module-attribute-pagination/view/adminhtml/templates/catalog/product/attribute/text.phtml
+++ b/src/module-attribute-pagination/view/adminhtml/templates/catalog/product/attribute/text.phtml
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+/**
+ * Copyright © Q-Solutions Studio: eCommerce Nanobots. All rights reserved.
+ * @author      Jakub Winkler <jwinkler@qsolutionsstudio.com>
+ *
+ * @category    Nanobots
+ * @package     Nanobots_AttributeOptionPager
+ */
+// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
+/** @var $block \Nanobots\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Text */
+
+$stores = $block->getStoresSortedBySortOrder();
+?>
+<fieldset class="fieldset">
+    <legend class="legend">
+        <span><?= $block->escapeHtml(__('Manage Swatch (Values of Your Attribute)')) ?></span>
+    </legend>
+    <div id="swatch-text-options-panel">
+        <div class="admin__data-grid-pager-wrap attribute-pager">
+            <label for="attributeGrid_page-limit"></label><select name="limit" id="attributeGrid_page-limit" class="admin__control-select">
+                <?php foreach ($block->getLimits() as $limit): ?>
+                    <option value="<?= $limit;?>" <?= $block->getCurrentPageSize() === $limit ? 'selected="selected"' : '';?> data-url="<?= $block->getNextUrl($limit , $block->getCurrentPageNumber()); ?>"><?= $limit; ?></option>
+                <?php endforeach; ?>
+            </select>
+            <label for="attributeGridattributeGrid_page-limit" class="admin__control-support-text"><?= __('per page'); ?></label>
+
+            <div class="admin__data-grid-pager">
+                <button type="button" class="attribute-pager-btn action-previous <?= $block->getCurrentPageNumber() === 1 ? 'disabled' :
+                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() - 1); ?>">
+                    <span><?= __('Previous page'); ?></span>
+                </button>
+                <input type="text" id="attributeGrid_page-current" name="page" value="<?= $block->getCurrentPageNumber(); ?>" class="admin__control-text" data-ui-id="adminhtml-product-attribute-grid-current-page">
+                <label class="admin__control-support-text" for="attributeGrid_page-current">
+                    <?= __('of');?> <span> <?= $block->getMaxPageCount(); ?> </span>                        </label>
+                <button type="button" class="attribute-pager-btn action-next <?= $block->getMaxPageCount() === $block->getCurrentPageNumber() ? ' disabled"' :
+                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() + 1); ?>">
+                    <span><?= __('Next page'); ?></span>
+                </button>
+            </div>
+        </div>
+        <table class="data-table clearfix" cellspacing="0">
+            <thead>
+            <tr id="swatch-text-options-table">
+                <th class="col-default"><span><?= $block->escapeHtml(__('Is Default')) ?></span></th>
+                <?php foreach ($stores as $_store) : ?>
+                    <th class="col-swatch col-swatch-min-width col-<%- data.id %><?= ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' _required' : '' ?>"
+                        colspan="2">
+                        <span><?= $block->escapeHtml($_store->getName()) ?></span>
+                    </th>
+                <?php endforeach; ?>
+                <th class="col-sort"><span><?= $block->escapeHtml(__('Sort Order')) ?></span></th>
+                <?php $colTotal = count($stores) * 2 + 3; ?>
+                <th class="col-delete">&nbsp;</th>
+            </tr>
+            </thead>
+            <tbody data-role="swatch-text-options-container" class="ignore-validate"></tbody>
+            <tfoot>
+            <tr>
+                <th colspan="<?= (int)$colTotal ?>">
+                    <input type="hidden" class="required-text-swatch-entry" name="text_swatch_validation"/>
+                    <input type="hidden" class="required-text-swatch-unique" name="text_swatch_validation_unique"/>
+                </th>
+            </tr>
+            <tr>
+                <th colspan="<?= (int)$colTotal ?>" class="col-actions-add">
+                    <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
+                        <button id="add_new_swatch_text_option_button"
+                                title="<?= $block->escapeHtml(__('Add Swatch')) ?>"
+                                type="button" class="action- scalable add">
+                            <span><?= $block->escapeHtml(__('Add Swatch')) ?></span>
+                        </button>
+                    <?php endif; ?>
+                </th>
+            </tr>
+            </tfoot>
+        </table>
+        <input type="hidden" id="swatch-text-option-count-check" value="" />
+    </div>
+    <script id="swatch-text-row-template" type="text/x-magento-template">
+        <tr>
+            <td class="col-default">
+                <input class="input-radio"
+                       type="<%- data.intype %>"
+                       name="defaulttext[]"
+                       value="<%- data.id %>" <%- data.checked %><?= ($block->getReadOnly()) ? ' disabled="disabled"' : '' ?>/>
+            </td>
+            <?php foreach ($stores as $_store) : ?>
+                <?php $storeId = (int)$_store->getId(); ?>
+                <td class="col-swatch col-swatch-min-width col-<%- data.id %>">
+                    <input class="input-text
+                        swatch-text-field-<?= /* @noEscape */ $storeId ?>
+                        <?= ($storeId == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' required-option required-unique' : '' ?>"
+                           name="swatchtext[value][<%- data.id %>][<?= /* @noEscape */ $storeId ?>]"
+                           type="text" value="<%- data.swatch<?= /* @noEscape */ $storeId ?> %>"
+                           placeholder="<?= $block->escapeHtmlAttr(__("Swatch")) ?>"/>
+                </td>
+                <td class="col-swatch-min-width swatch-col-<%- data.id %>">
+                    <input name="optiontext[value][<%- data.id %>][<?= /* @noEscape */ $storeId ?>]"
+                           value="<%- data.store<?= /* @noEscape */ $storeId ?> %>"
+                           class="input-text<?= ($storeId == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' required-option' : '' ?>"
+                           type="text" <?= ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) ? ' disabled="disabled"' : ''?>
+                           placeholder="<?= $block->escapeHtmlAttr(__("Description")) ?>"/>
+                </td>
+            <?php endforeach; ?>
+            <td class="col-default">
+                <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
+                    <input data-role="order" type="text" name="optiontext[order][<%- data.id %>]" size="6" value="<%- data.sort_order %>" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif; ?>/>
+                <?php endif; ?>
+            </td>
+            <td id="delete_button_swatch_container_<%- data.id %>" class="col-delete">
+                <input type="hidden" class="delete-flag" name="optiontext[delete][<%- data.id %>]" value="" />
+                <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
+                    <button title="<?= $block->escapeHtmlAttr(__('Delete')) ?>" type="button"
+                            class="action- scalable delete delete-option">
+                        <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                    </button>
+                <?php endif;?>
+            </td>
+        </tr>
+    </script>
+    <script type="text/x-magento-init">
+        {
+            "*": {
+                "Magento_Swatches/js/text": <?= /* @noEscape */ $block->getJsonConfig() ?> ,
+                "Magento_Catalog/catalog/product/attribute/unique-validate": {
+                    "element": "required-text-swatch-unique",
+                    "message": "<?= $block->escapeJs($block->escapeHtml(__("The value of Admin must be unique."))) ?>"
+                },
+                "Nanobots_AttributeOptionPager/js/pager": {
+                    "ajaxUrlValue": {}
+                }
+            }
+        }
+    </script>
+</fieldset>

--- a/src/module-attribute-pagination/view/adminhtml/templates/catalog/product/attribute/visual.phtml
+++ b/src/module-attribute-pagination/view/adminhtml/templates/catalog/product/attribute/visual.phtml
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+/**
+ * Copyright © Q-Solutions Studio: eCommerce Nanobots. All rights reserved.
+ * @author      Jakub Winkler <jwinkler@qsolutionsstudio.com>
+ *
+ * @category    Nanobots
+ * @package     Nanobots_AttributeOptionPager
+ */
+// phpcs:disable PHPCompatibility.Miscellaneous.RemovedAlternativePHPTags.MaybeASPOpenTagFound
+/** @var $block \Nanobots\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Text */
+
+$stores = $block->getStoresSortedBySortOrder();
+?>
+<fieldset class="admin__fieldset fieldset">
+    <legend class="legend">
+        <span><?= $block->escapeHtml(__('Manage Swatch (Values of Your Attribute)')) ?></span>
+    </legend><br />
+    <div class="admin__control-table-wrapper" id="swatch-visual-options-panel">
+        <div class="admin__data-grid-pager-wrap attribute-pager">
+            <label for="attributeGrid_page-limit"></label><select name="limit" id="attributeGrid_page-limit" class="admin__control-select">
+                <?php foreach ($block->getLimits() as $limit): ?>
+                    <option value="<?= $limit;?>" <?= $block->getCurrentPageSize() === $limit ? 'selected="selected"' : '';?> data-url="<?= $block->getNextUrl($limit , $block->getCurrentPageNumber()); ?>"><?= $limit; ?></option>
+                <?php endforeach; ?>
+            </select>
+            <label for="attributeGridattributeGrid_page-limit" class="admin__control-support-text"><?= __('per page'); ?></label>
+
+            <div class="admin__data-grid-pager">
+                <button type="button" class="attribute-pager-btn action-previous <?= $block->getCurrentPageNumber() === 1 ? 'disabled' :
+                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() - 1); ?>">
+                    <span><?= __('Previous page'); ?></span>
+                </button>
+                <input type="text" id="attributeGrid_page-current" name="page" value="<?= $block->getCurrentPageNumber(); ?>" class="admin__control-text" data-ui-id="adminhtml-product-attribute-grid-current-page">
+                <label class="admin__control-support-text" for="attributeGrid_page-current">
+                    <?= __('of');?> <span> <?= $block->getMaxPageCount(); ?> </span>                        </label>
+                <button type="button" class="attribute-pager-btn action-next <?= $block->getMaxPageCount() === $block->getCurrentPageNumber() ? ' disabled"' :
+                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() + 1); ?>">
+                    <span><?= __('Next page'); ?></span>
+                </button>
+            </div>
+        </div>
+        <table class="data-table clearfix" cellspacing="0">
+            <thead>
+            <tr id="swatch-visual-options-table">
+                <th class="col-default"><span><?= $block->escapeHtml(__('Is Default')) ?></span></th>
+                <th><span><?= $block->escapeHtml(__('Swatch')) ?></span></th>
+                <?php foreach ($stores as $_store) : ?>
+                    <th<?= ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' class="_required"' : '' ?>
+                        <span><?= $block->escapeHtml($_store->getName()) ?></span>
+                    </th>
+                <?php endforeach; ?>
+                <th class="col-sort"><span><?= $block->escapeHtml(__('Sort Order')) ?></span></th>
+                <?php $colTotal = count($stores) * 2 + 3; ?>
+                <th class="col-delete">&nbsp;</th>
+            </tr>
+            </thead>
+            <tbody data-role="swatch-visual-options-container" class="ignore-validate"></tbody>
+            <tfoot>
+            <tr>
+                <th colspan="<?= (int)$colTotal ?>">
+                    <input type="hidden" class="required-visual-swatch-entry" name="visual_swatch_validation"/>
+                    <input type="hidden" class="required-visual-swatch-unique" name="visual_swatch_validation_unique"/>
+                </th>
+            </tr>
+            <tr>
+                <th colspan="<?= (int)$colTotal ?>" class="col-actions-add">
+                    <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
+                        <button id="add_new_swatch_visual_option_button"
+                                title="<?= $block->escapeHtml(__('Add Swatch')) ?>"
+                                type="button" class="action- scalable add">
+                            <span><?= $block->escapeHtml(__('Add Swatch')) ?></span>
+                        </button>
+                    <?php endif; ?>
+                </th>
+            </tr>
+            </tfoot>
+        </table>
+        <input type="hidden" id="swatch-visual-option-count-check" value="" />
+    </div>
+    <script id="swatch-visual-row-template" type="text/x-magento-template">
+        <tr>
+
+            <td class="col-default">
+                <input class="input-radio" type="<%- data.intype %>" name="defaultvisual[]" value="<%- data.id %>" <%- data.checked %><?= ($block->getReadOnly()) ? ' disabled="disabled"' : '' ?>/>
+            </td>
+            <td class="swatches-visual-col col-default <%- data.empty_class %>">
+                <?php //@todo add logic getting swatch value from db */ ?>
+                <input id="swatch_visual_value_<%- data.id %>" type="hidden" name="swatchvisual[value][<%- data.id %>]" value="<%- data.defaultswatch0 %>" />
+                <div class="swatch_window" id="swatch_window_option_<%- data.id %>" style="<%- data.swatch0 %>"></div>
+                <div class="swatch_sub-menu_container" id="swatch_container_option_<%- data.id %>">
+                    <div class="swatch_row position-relative">
+                        <div class="swatch_row_name colorpicker_handler">
+                            <p><?= $block->escapeHtml(__('Choose a color')) ?></p>
+                        </div>
+                    </div>
+                    <div class="swatch_row">
+                        <div class="swatch_row_name btn_choose_file_upload" id="swatch_choose_file_option_<%- data.id %>">
+                            <p><?= $block->escapeHtml(__('Upload a file')) ?></p>
+                        </div>
+                    </div>
+                    <div class="swatch_row">
+                        <div class="swatch_row_name btn_remove_swatch">
+                            <p><?= $block->escapeHtml(__('Clear')) ?></p>
+                        </div>
+                    </div>
+                </div>
+            </td>
+            <?php foreach ($stores as $_store) : ?>
+                <td class="swatch-col-<%- data.id %>">
+                    <input name="optionvisual[value][<%- data.id %>][<?= (int)$_store->getId() ?>]"
+                           value="<%- data.store<?= (int) $_store->getId() ?> %>"
+                           class="input-text<?= ($_store->getId() == \Magento\Store\Model\Store::DEFAULT_STORE_ID) ? ' required-option required-unique' : '' ?>"
+                           type="text" <?= ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) ? ' disabled="disabled"' : '' ?>/>
+                </td>
+            <?php endforeach; ?>
+            <td class="col-default">
+                <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
+                    <input data-role="order" type="text" name="optionvisual[order][<%- data.id %>]" size="6" value="<%- data.sort_order %>" <?php if ($block->getReadOnly() || $block->canManageOptionDefaultOnly()) :?> disabled="disabled"<?php endif; ?>/>
+                <?php endif; ?>
+            </td>
+            <td id="delete_button_swatch_container_<%- data.id %>" class="col-delete">
+                <input type="hidden" class="delete-flag" name="optionvisual[delete][<%- data.id %>]" value="" />
+                <?php if (!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) : ?>
+                    <button title="<?= $block->escapeHtml(__('Delete')) ?>" type="button"
+                            class="action- scalable delete delete-option">
+                        <span><?= $block->escapeHtml(__('Delete')) ?></span>
+                    </button>
+                <?php endif;?>
+            </td>
+        </tr>
+    </script>
+    <script type="text/x-magento-init">
+        {
+            "*": {
+                "Magento_Swatches/js/visual": <?= /* @noEscape */ $block->getJsonConfig() ?> ,
+                "Magento_Catalog/catalog/product/attribute/unique-validate": {
+                    "element": "required-visual-swatch-unique",
+                    "message": "<?= $block->escapeHtml(__("The value of Admin must be unique.")) ?>"
+                },
+                "Nanobots_AttributeOptionPager/js/pager": {
+                    "ajaxUrlValue": {}
+                }
+            }
+        }
+    </script>
+</fieldset>


### PR DESCRIPTION
Adds support for Text/Visual swatches

 - Saving attrbute options works
 - Pagination works
 - Sort order works

![image](https://github.com/user-attachments/assets/319b696b-15a6-48ac-a905-cf8b6b234063)
![image](https://github.com/user-attachments/assets/0f856052-428f-4458-aefc-eab1a676c1fd)

Jumping to a page doesn't seem to work, but that doesn't work for the normal options either.
Ordering this is still a bit of a pain but at least the page loads.

The code duplication is a bit icky, so this is more of a 'proof of concept' PR, I'm sure it can be optimized but not sure what the best way is. Perhaps we can extract it to a Trait and override from there?
