### PR TITLE
Added filtering, switched to ajax pagination, added pagination to bottom of table

### DIFF
--- a/Block/Adminhtml/Attribute/Edit/Options/PaginationTrait.php
+++ b/Block/Adminhtml/Attribute/Edit/Options/PaginationTrait.php
@@ -25,6 +25,39 @@ trait PaginationTrait
     /** @var int[]  */
     protected static array $limit = [20, 30, 50, 100, 200];
 
+    protected function getCurrentFilterQuery(): string
+    {
+        return trim((string)$this->getRequest()->getParam('option_filter', ''));
+    }
+
+    protected function applyFilterToCollection(Collection $collection): Collection
+    {
+        $filterQuery = $this->getCurrentFilterQuery();
+
+        if ($filterQuery === '') {
+            return $collection;
+        }
+
+        $collection->getSelect()->where(
+            'sort_alpha_value.value LIKE ?',
+            '%' . addcslashes($filterQuery, '%_') . '%'
+        );
+
+        return $collection;
+    }
+
+    protected function getFilteredOptionCollection(AbstractAttribute $attribute): Collection
+    {
+        $collection = $this->_attrOptionCollectionFactory->create()->setAttributeFilter(
+            $attribute->getId()
+        )->setPositionOrder(
+            'asc',
+            true
+        );
+
+        return $this->applyFilterToCollection($collection);
+    }
+
     /**
      * Retrieve option values collection
      *
@@ -42,13 +75,8 @@ trait PaginationTrait
                 $attribute
             )->getAllOptions();
         } else {
-            return $this->_attrOptionCollectionFactory->create()->setAttributeFilter(
-                $attribute->getId()
-            )->setPositionOrder(
-                'asc',
-                true
-            )->setPageSize($this->getRequest()->getParam('limit') ?? static::$defaultLimit)
-                ->setCurPage($this->getRequest()->getParam('page') ?? static::$defaultPage)
+            return $this->getFilteredOptionCollection($attribute)->setPageSize($this->getCurrentPageSize())
+                ->setCurPage($this->getCurrentPageNumber())
                 ->load();
         }
     }
@@ -79,7 +107,7 @@ trait PaginationTrait
         if ($isSystemAttribute) {
             $values = $this->getPreparedValues($optionCollection, $isSystemAttribute, $inputType, $defaultValues);
         } else {
-            $optionCollection->setPageSize($this->getRequest()->getParam('limit'));
+            $optionCollection->setPageSize($this->getCurrentPageSize());
             $values = array_merge(
                 $values,
                 $this->getPreparedValues($optionCollection, $isSystemAttribute, $inputType, $defaultValues)
@@ -149,10 +177,9 @@ trait PaginationTrait
      */
     public function getCurrentPageNumber(): int
     {
-        if ($this->getRequest()->getParam('page')) {
-            return (int)$this->getRequest()->getParam('page');
-        }
-        return static::$defaultPage;
+        $page = (int)$this->getRequest()->getParam('page', static::$defaultPage);
+
+        return max(static::$defaultPage, min($page, $this->getMaxPageCount()));
     }
 
     /**
@@ -161,8 +188,9 @@ trait PaginationTrait
     public function getCurrentPageSize(): int
     {
         if ($this->getRequest()->getParam('limit')) {
-            return (int)$this->getRequest()->getParam('limit');
+            return max(1, (int)$this->getRequest()->getParam('limit'));
         }
+
         return static::$defaultLimit;
     }
 
@@ -180,11 +208,13 @@ trait PaginationTrait
     public function getMaxPageCount(): int
     {
         $attribute = $this->getAttributeObject();
-        return $this->_attrOptionCollectionFactory->create()->setAttributeFilter(
-            $attribute->getId()
-        )->setPageSize($this->getRequest()->getParam('limit') ?? static::$defaultLimit)
-            ->getLastPageNumber();
 
+        return max(
+            static::$defaultPage,
+            (int)$this->getFilteredOptionCollection($attribute)
+                ->setPageSize($this->getCurrentPageSize())
+                ->getLastPageNumber()
+        );
     }
 
     /**
@@ -199,4 +229,57 @@ trait PaginationTrait
         $requestParams['limit'] = $limit;
         return $this->getUrl('*/*/*', $requestParams);
     }
+
+    /**
+     * @return array<int, array<string, mixed>|mixed>
+     */
+    public function getOptionValuesData(): array
+    {
+        $values = [];
+
+        foreach ($this->getOptionValues() as $value) {
+            $value = $value->getData();
+            $values[] = is_array($value) ? array_map(static function ($str) {
+                return htmlspecialchars_decode($str, ENT_QUOTES);
+            }, $value) : $value;
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return array<string, int|array<int, int>>
+     */
+    public function getPaginationData(): array
+    {
+        return [
+            'currentPage' => $this->getCurrentPageNumber(),
+            'pageSize' => $this->getCurrentPageSize(),
+            'maxPageCount' => $this->getMaxPageCount(),
+            'limits' => $this->getLimits(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPagerRequestParams(): array
+    {
+        $requestParams = $this->getRequest()->getParams();
+
+        unset($requestParams['key'], $requestParams['isAjax'], $requestParams['panel']);
+
+        return $requestParams;
+    }
+
+    public function getPagerAjaxUrl(): string
+    {
+        return $this->getUrl('qoliber_attributeoptionpager/pager/options');
+    }
+
+    public function getCurrentFilterValue(): string
+    {
+        return $this->getCurrentFilterQuery();
+    }
+
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,69 +1,23 @@
-# Changelog
-All notable changes to this project will be documented in this file.
+# Change Log
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## Version 1.0.6
+* fix jump-to-page directly
 
-## [2.0.1] - 2025-04-30
-### Fixed
-- Fixed trait constant declarations for PHP 8.1 compatibility in PaginationTrait
-- Resolved PHP 8.1 deprecation warnings for trait constants
+## Version 1.0.5
+* add support for text/visual swatches
 
-## [2.0.0] - 2024-12-19
-### Added
-- Added pagination support for text swatches in attribute option management
-- Added pagination support for visual swatches in attribute option management
-- Implemented dedicated block classes for text and visual swatch option pagination
-- Added PaginationTrait to share pagination logic across different swatch types
+## Version 1.0.4
+* Fix requireconfig js load error
 
-### Changed
-- Restructured module directory from `src/module-attribute-pagination/` to root directory
-- Updated module structure to align with Magento 2 best practices
-- Improved template organization for different attribute option types
+## Version 1.0.3
+* Checking if attribute default value is null, happens with 3rd party attribute import
 
-### Fixed
-- Fixed colspan calculation for text and visual swatch templates
-- Fixed input width consistency across different swatch types
-- Fixed current pagination page display in JavaScript pager
-- Fixed pagination size handling in templates
+## Version 1.0.2
+* adding sort order field to attribute options
+* adding CHANGELOG.md file
 
-## [1.0.6] - 2024-11-12
-### Fixed
-- Fixed jump-to-page functionality for direct page navigation in attribute option grid
+## Version 1.0.1
+* code updates
 
-## [1.0.5] - 2024-11-12
-### Added
-- Added comprehensive pagination support for text and visual swatches
-- Implemented swatch-specific pagination templates for improved admin UX with large swatch collections
-
-## [1.0.4] - 2023-09-02
-### Fixed
-- Fixed requirejs loading error in attribute options template
-- Resolved JavaScript module loading issues in admin panel
-
-## [1.0.3] - 2022-10-18
-### Fixed
-- Fixed handling of null default attribute values in third-party attribute imports
-- Added null check validation for attribute default values
-
-## [1.0.2] - 2021-11-24
-### Added
-- Implemented sort order input field for attribute options replacing drag-and-drop
-- Added CHANGELOG.md file to track version history
-- Improved performance for managing attributes with 100+ options
-
-### Changed
-- Replaced drag-and-drop sorting with manual sort order input field for better scalability
-
-## [1.0.1] - 2021-11-24
-### Changed
-- Code updates and improvements
-
-## [1.0.0] - 2021-09-26
-### Added
-- Initial release of Attribute Option Pagination module
-- Implemented server-side pagination for attribute options with 100+ entries in Magento admin panel
-- Added JavaScript-based pager component for seamless navigation through large attribute option lists
-- Enabled efficient management of dropdown attributes with hundreds of options
-- Reduced admin panel page load times for attributes with extensive option sets
-- Added LESS styling for pagination interface in attribute option management
+## Version 1.0.0
+* initial module release

--- a/Controller/Adminhtml/Pager/Options.php
+++ b/Controller/Adminhtml/Pager/Options.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Copyright © qoliber. All rights reserved.
+ *
+ * @category    Qoliber
+ * @package     Qoliber_AttributeOptionPager
+ */
+
+declare(strict_types=1);
+
+namespace Qoliber\AttributeOptionPager\Controller\Adminhtml\Pager;
+
+use Magento\Backend\App\Action;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Frontend\Inputtype\Presentation;
+use Magento\Catalog\Model\ResourceModel\Eav\Attribute as AttributeModel;
+use Magento\Catalog\Model\ResourceModel\Eav\AttributeFactory;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Registry;
+use Magento\Framework\View\LayoutFactory;
+use Magento\Eav\Model\Entity;
+use Magento\Eav\Model\EntityFactory;
+use Qoliber\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Options as OptionsBlock;
+use Qoliber\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Text as TextBlock;
+use Qoliber\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Visual as VisualBlock;
+
+class Options extends Action
+{
+    public const ADMIN_RESOURCE = 'Magento_Catalog::attributes_attributes';
+
+    /**
+     * @var array<string, class-string>
+     */
+    private array $blockMap = [
+        'options' => OptionsBlock::class,
+        'text' => TextBlock::class,
+        'visual' => VisualBlock::class,
+    ];
+
+    public function __construct(
+        Action\Context $context,
+        private readonly JsonFactory $resultJsonFactory,
+        private readonly LayoutFactory $layoutFactory,
+        private readonly Registry $registry,
+        private readonly AttributeFactory $attributeFactory,
+        private readonly EntityFactory $entityFactory,
+        private readonly Presentation $presentation
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute(): Json
+    {
+        /** @var Json $result */
+        $result = $this->resultJsonFactory->create();
+        $panel = (string)$this->getRequest()->getParam('panel');
+        $attribute = $this->getAttribute();
+
+        if (!isset($this->blockMap[$panel]) || !$attribute) {
+            return $result->setHttpResponseCode(400)->setData([
+                'error' => true,
+                'message' => __('Unable to load the requested attribute option panel.'),
+            ]);
+        }
+
+        $layout = $this->layoutFactory->create();
+        $blockClass = $this->blockMap[$panel];
+        $block = $layout->createBlock($blockClass);
+
+        return $result->setData([
+            'error' => false,
+            'attributesData' => $block->getOptionValuesData(),
+            'pagination' => $block->getPaginationData(),
+            'currentUrl' => $this->getEditPageUrl(
+                (int)$block->getPaginationData()['currentPage'],
+                (int)$block->getPaginationData()['pageSize']
+            ),
+        ]);
+    }
+
+    private function getAttribute(): ?AttributeModel
+    {
+        $attributeId = (int)$this->getRequest()->getParam('attribute_id');
+
+        if ($attributeId <= 0) {
+            return null;
+        }
+
+        /** @var AttributeModel $attribute */
+        $attribute = $this->attributeFactory->create();
+        $attribute->setEntityTypeId($this->getEntityTypeId());
+        $attribute->load($attributeId);
+
+        if (!$attribute->getId() || (int)$attribute->getEntityTypeId() !== $this->getEntityTypeId()) {
+            return null;
+        }
+
+        $attribute->setFrontendInput($this->presentation->getPresentationInputType($attribute));
+
+        if ($this->registry->registry('entity_attribute')) {
+            $this->registry->unregister('entity_attribute');
+        }
+        $this->registry->register('entity_attribute', $attribute);
+
+        return $attribute;
+    }
+
+    private function getEntityTypeId(): int
+    {
+        return (int)$this->entityFactory->create()
+            ->setType(Product::ENTITY)
+            ->getTypeId();
+    }
+
+    private function getEditPageUrl(int $page, int $limit): string
+    {
+        $requestParams = $this->getRequest()->getParams();
+
+        unset($requestParams['isAjax'], $requestParams['panel'], $requestParams['key']);
+
+        $requestParams['page'] = $page;
+        $requestParams['limit'] = $limit;
+
+        return $this->_url->getUrl('catalog/product_attribute/edit', $requestParams);
+    }
+}

--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="admin">
+        <route id="qoliber_attributeoptionpager" frontName="qoliber_attributeoptionpager">
+            <module name="Qoliber_AttributeOptionPager"/>
+        </route>
+    </router>
+</config>

--- a/view/adminhtml/templates/catalog/product/attribute/options.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/options.phtml
@@ -11,35 +11,60 @@ use Qoliber\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Options;
 
 /** @var $block Options */
 $stores = $block->getStoresSortedBySortOrder();
+$pagination = $block->getPaginationData();
+$renderPager = static function (Options $block, string $suffix, string $extraClass = '', bool $showFilter = false): string {
+    $pagination = $block->getPaginationData();
+
+    ob_start();
+    ?>
+    <div class="admin__data-grid-pager-wrap attribute-pager<?= $extraClass ? ' ' . $block->escapeHtmlAttr($extraClass) : '' ?>">
+        <?php if ($showFilter): ?>
+            <div class="attribute-pager-filter">
+                <label for="attribute-options-filter" class="admin__control-support-text"><?= $block->escapeHtml(__('Filter options')) ?></label>
+                <input type="text"
+                       id="attribute-options-filter"
+                       class="admin__control-text attribute-pager-filter-input"
+                       value="<?= $block->escapeHtmlAttr($block->getCurrentFilterValue()) ?>"
+                       placeholder="<?= $block->escapeHtmlAttr(__('Search option label')) ?>">
+                <button type="button" class="action-secondary attribute-pager-filter-btn">
+                    <span><?= $block->escapeHtml(__('Filter')) ?></span>
+                </button>
+                <button type="button" class="action-secondary attribute-pager-filter-clear-btn">
+                    <span><?= $block->escapeHtml(__('Clear')) ?></span>
+                </button>
+            </div>
+        <?php endif; ?>
+        <label for="attributeGrid_page-limit-<?= $block->escapeHtmlAttr($suffix) ?>"></label><select name="limit" id="attributeGrid_page-limit-<?= $block->escapeHtmlAttr($suffix) ?>" class="admin__control-select attribute-pager-limit">
+            <?php foreach ($block->getLimits() as $limit): ?>
+                <option value="<?= $limit; ?>" <?= $pagination['pageSize'] === $limit ? 'selected="selected"' : ''; ?>><?= $limit; ?></option>
+            <?php endforeach; ?>
+        </select>
+        <label for="attributeGrid_page-limit-<?= $block->escapeHtmlAttr($suffix) ?>" class="admin__control-support-text"><?= __('per page'); ?></label>
+
+        <div class="admin__data-grid-pager">
+            <button type="button" class="attribute-pager-btn action-previous<?= $pagination['currentPage'] === 1 ? ' disabled' : '' ?>" data-page="<?= max(1, $pagination['currentPage'] - 1) ?>">
+                <span><?= __('Previous page'); ?></span>
+            </button>
+            <input type="number" id="attributeGrid_page-current-<?= $block->escapeHtmlAttr($suffix) ?>" min="1" max="<?= $pagination['maxPageCount'] ?>" name="page" value="<?= $pagination['currentPage']; ?>"
+                   class="admin__control-text attribute-pager-current" data-ui-id="adminhtml-product-attribute-grid-current-page">
+            <label class="admin__control-support-text" for="attributeGrid_page-current-<?= $block->escapeHtmlAttr($suffix) ?>">
+                <?= __('of'); ?> <span class="attribute-pager-total-pages"><?= $pagination['maxPageCount']; ?></span></label>
+            <button type="button" class="attribute-pager-btn action-next<?= $pagination['maxPageCount'] === $pagination['currentPage'] ? ' disabled' : '' ?>" data-page="<?= min($pagination['maxPageCount'], $pagination['currentPage'] + 1) ?>">
+                <span><?= __('Next page'); ?></span>
+            </button>
+        </div>
+    </div>
+    <?php
+
+    return trim(ob_get_clean());
+};
 ?>
 <fieldset class="admin__fieldset fieldset">
     <legend class="legend">
         <span><?= $block->escapeHtml(__('Manage Options (Values of Your Attribute)' )) ?></span>
     </legend><br />
     <div class="admin__control-table-wrapper" id="manage-options-panel" data-index="attribute_options_select_container">
-        <div class="admin__data-grid-pager-wrap attribute-pager">
-            <label for="attributeGrid_page-limit"></label><select name="limit" id="attributeGrid_page-limit" class="admin__control-select attribute-pager-limit">
-                <?php foreach ($block->getLimits() as $limit): ?>
-                    <option value="<?= $limit;?>" <?= $block->getCurrentPageSize() === $limit ? 'selected="selected"' : '';?> data-url="<?= $block->getNextUrl($limit , $block->getCurrentPageNumber()); ?>"><?= $limit; ?></option>
-                <?php endforeach; ?>
-            </select>
-            <label for="attributeGridattributeGrid_page-limit" class="admin__control-support-text"><?= __('per page'); ?></label>
-
-            <div class="admin__data-grid-pager">
-                <button type="button" class="attribute-pager-btn action-previous <?= $block->getCurrentPageNumber() === 1 ? 'disabled' :
-                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() - 1); ?>">
-                    <span><?= __('Previous page'); ?></span>
-                </button>
-                <input type="number" id="attributeGrid_page-current" min="1" max="<?= $block->getMaxPageCount() ?>" name="page" value="<?= $block->getCurrentPageNumber(); ?>"
-                       data-url="<?= $block->getNextUrl($block->getCurrentPageSize() , 0) ?>" class="admin__control-text attribute-pager-current" data-ui-id="adminhtml-product-attribute-grid-current-page">
-                <label class="admin__control-support-text" for="attributeGrid_page-current">
-                    <?= __('of');?> <span> <?= $block->getMaxPageCount(); ?> </span>                        </label>
-                <button type="button" class="attribute-pager-btn action-next <?= $block->getMaxPageCount() === $block->getCurrentPageNumber() ? ' disabled"' :
-                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() + 1); ?>">
-                    <span><?= __('Next page'); ?></span>
-                </button>
-            </div>
-        </div>
+        <?= /** @noEscape */ $renderPager($block, 'top', '', true) ?>
         <table class="admin__control-table" data-index="attribute_options_select">
             <thead>
             <tr id="attribute-options-table">
@@ -80,6 +105,7 @@ $stores = $block->getStoresSortedBySortOrder();
             </tr>
             </tfoot>
         </table>
+        <?= /** @noEscape */ $renderPager($block, 'bottom', 'attribute-pager-bottom') ?>
         <input type="hidden" id="option-count-check" value="" />
     </div>
     <script id="row-template" type="text/x-magento-template">
@@ -107,20 +133,11 @@ $stores = $block->getStoresSortedBySortOrder();
         </td>
         </tr>
     </script>
-    <?php
-    $values = [];
-    foreach ($block->getOptionValues() as $value) {
-        $value = $value->getData();
-        $values[] = is_array($value) ? array_map(function ($str) {
-            return htmlspecialchars_decode($str, ENT_QUOTES);
-        }, $value) : $value;
-    }
-    ?>
     <script type="text/x-magento-init">
         {
             "*": {
                 "Magento_Catalog/js/options": {
-                    "attributesData": <?= /* @noEscape */ json_encode($values, JSON_HEX_QUOT) ?>,
+                    "attributesData": <?= /* @noEscape */ json_encode($block->getOptionValuesData(), JSON_HEX_QUOT) ?>,
                     "isSortable":  <?= (int)(!$block->getReadOnly() && !$block->canManageOptionDefaultOnly()) ?>,
                     "isReadOnly": <?= (int)$block->getReadOnly() ?>
                 },
@@ -129,7 +146,14 @@ $stores = $block->getStoresSortedBySortOrder();
                     "message": "<?= $block->escapeHtml(__("The value of Admin must be unique.")) ?>"
                 },
                 "Qoliber_AttributeOptionPager/js/pager": {
-                    "ajaxUrlValue": {}
+                    "ajaxUrl": "<?= $block->escapeUrl($block->getPagerAjaxUrl()) ?>",
+                    "panelId": "manage-options-panel",
+                    "panelType": "options",
+                    "containerSelector": "[data-role=options-container]",
+                    "registryKey": "manage-options-panel",
+                    "filterSelector": ".attribute-pager-filter-input",
+                    "requestParams": <?= /* @noEscape */ json_encode($block->getPagerRequestParams(), JSON_HEX_QUOT) ?>,
+                    "pagination": <?= /* @noEscape */ json_encode($pagination, JSON_HEX_QUOT) ?>
                 }
             }
         }

--- a/view/adminhtml/templates/catalog/product/attribute/text.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/text.phtml
@@ -22,6 +22,20 @@ $pagination = $block->getPaginationData();
     </legend>
     <div id="swatch-text-options-panel">
         <div class="admin__data-grid-pager-wrap attribute-pager">
+            <div class="attribute-pager-filter">
+                <label for="swatch-text-options-filter" class="admin__control-support-text"><?= $block->escapeHtml(__('Filter options')) ?></label>
+                <input type="text"
+                       id="swatch-text-options-filter"
+                       class="admin__control-text attribute-pager-filter-input"
+                       value="<?= $block->escapeHtmlAttr($block->getCurrentFilterValue()) ?>"
+                       placeholder="<?= $block->escapeHtmlAttr(__('Search option label')) ?>">
+                <button type="button" class="action-secondary attribute-pager-filter-btn">
+                    <span><?= $block->escapeHtml(__('Filter')) ?></span>
+                </button>
+                <button type="button" class="action-secondary attribute-pager-filter-clear-btn">
+                    <span><?= $block->escapeHtml(__('Clear')) ?></span>
+                </button>
+            </div>
             <label for="attributeGrid_page-limit"></label><select name="limit" id="attributeGrid_page-limit" class="admin__control-select attribute-pager-limit">
                 <?php foreach ($block->getLimits() as $limit): ?>
                     <option value="<?= $limit; ?>" <?= $pagination['pageSize'] === $limit ? 'selected="selected"' : ''; ?>><?= $limit; ?></option>
@@ -136,6 +150,7 @@ $pagination = $block->getPaginationData();
                     "panelType": "text",
                     "containerSelector": "[data-role=swatch-text-options-container]",
                     "registryKey": "swatch-text-options-panel",
+                    "filterSelector": ".attribute-pager-filter-input",
                     "requestParams": <?= /* @noEscape */ json_encode($block->getPagerRequestParams(), JSON_HEX_QUOT) ?>,
                     "pagination": <?= /* @noEscape */ json_encode($pagination, JSON_HEX_QUOT) ?>
                 }

--- a/view/adminhtml/templates/catalog/product/attribute/text.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/text.phtml
@@ -14,6 +14,7 @@
 /** @var $block \Qoliber\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Text */
 
 $stores = $block->getStoresSortedBySortOrder();
+$pagination = $block->getPaginationData();
 ?>
 <fieldset class="fieldset">
     <legend class="legend">
@@ -23,22 +24,20 @@ $stores = $block->getStoresSortedBySortOrder();
         <div class="admin__data-grid-pager-wrap attribute-pager">
             <label for="attributeGrid_page-limit"></label><select name="limit" id="attributeGrid_page-limit" class="admin__control-select attribute-pager-limit">
                 <?php foreach ($block->getLimits() as $limit): ?>
-                    <option value="<?= $limit;?>" <?= $block->getCurrentPageSize() === $limit ? 'selected="selected"' : '';?> data-url="<?= $block->getNextUrl($limit , $block->getCurrentPageNumber()); ?>"><?= $limit; ?></option>
+                    <option value="<?= $limit; ?>" <?= $pagination['pageSize'] === $limit ? 'selected="selected"' : ''; ?>><?= $limit; ?></option>
                 <?php endforeach; ?>
             </select>
             <label for="attributeGridattributeGrid_page-limit" class="admin__control-support-text"><?= __('per page'); ?></label>
 
             <div class="admin__data-grid-pager">
-                <button type="button" class="attribute-pager-btn action-previous <?= $block->getCurrentPageNumber() === 1 ? 'disabled' :
-                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() - 1); ?>">
+                <button type="button" class="attribute-pager-btn action-previous<?= $pagination['currentPage'] === 1 ? ' disabled' : '' ?>" data-page="<?= max(1, $pagination['currentPage'] - 1) ?>">
                     <span><?= __('Previous page'); ?></span>
                 </button>
-                <input type="number" id="attributeGrid_page-current" min="1" max="<?= $block->getMaxPageCount() ?>" name="page" value="<?= $block->getCurrentPageNumber(); ?>"
-                       data-url="<?= $block->getNextUrl($block->getCurrentPageSize() , 0) ?>" class="admin__control-text attribute-pager-current" data-ui-id="adminhtml-product-attribute-grid-current-page">
+                <input type="number" id="attributeGrid_page-current" min="1" max="<?= $pagination['maxPageCount'] ?>" name="page" value="<?= $pagination['currentPage']; ?>"
+                       class="admin__control-text attribute-pager-current" data-ui-id="adminhtml-product-attribute-grid-current-page">
                 <label class="admin__control-support-text" for="attributeGrid_page-current">
-                    <?= __('of');?> <span> <?= $block->getMaxPageCount(); ?> </span>                        </label>
-                <button type="button" class="attribute-pager-btn action-next <?= $block->getMaxPageCount() === $block->getCurrentPageNumber() ? ' disabled"' :
-                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() + 1); ?>">
+                    <?= __('of');?> <span class="attribute-pager-total-pages"><?= $pagination['maxPageCount']; ?></span></label>
+                <button type="button" class="attribute-pager-btn action-next<?= $pagination['maxPageCount'] === $pagination['currentPage'] ? ' disabled' : '' ?>" data-page="<?= min($pagination['maxPageCount'], $pagination['currentPage'] + 1) ?>">
                     <span><?= __('Next page'); ?></span>
                 </button>
             </div>
@@ -132,7 +131,13 @@ $stores = $block->getStoresSortedBySortOrder();
                     "message": "<?= $block->escapeJs($block->escapeHtml(__("The value of Admin must be unique."))) ?>"
                 },
                 "Qoliber_AttributeOptionPager/js/pager": {
-                    "ajaxUrlValue": {}
+                    "ajaxUrl": "<?= $block->escapeUrl($block->getPagerAjaxUrl()) ?>",
+                    "panelId": "swatch-text-options-panel",
+                    "panelType": "text",
+                    "containerSelector": "[data-role=swatch-text-options-container]",
+                    "registryKey": "swatch-text-options-panel",
+                    "requestParams": <?= /* @noEscape */ json_encode($block->getPagerRequestParams(), JSON_HEX_QUOT) ?>,
+                    "pagination": <?= /* @noEscape */ json_encode($pagination, JSON_HEX_QUOT) ?>
                 }
             }
         }

--- a/view/adminhtml/templates/catalog/product/attribute/visual.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/visual.phtml
@@ -22,6 +22,20 @@ $pagination = $block->getPaginationData();
     </legend><br />
     <div class="admin__control-table-wrapper" id="swatch-visual-options-panel">
         <div class="admin__data-grid-pager-wrap attribute-pager">
+            <div class="attribute-pager-filter">
+                <label for="swatch-visual-options-filter" class="admin__control-support-text"><?= $block->escapeHtml(__('Filter options')) ?></label>
+                <input type="text"
+                       id="swatch-visual-options-filter"
+                       class="admin__control-text attribute-pager-filter-input"
+                       value="<?= $block->escapeHtmlAttr($block->getCurrentFilterValue()) ?>"
+                       placeholder="<?= $block->escapeHtmlAttr(__('Search option label')) ?>">
+                <button type="button" class="action-secondary attribute-pager-filter-btn">
+                    <span><?= $block->escapeHtml(__('Filter')) ?></span>
+                </button>
+                <button type="button" class="action-secondary attribute-pager-filter-clear-btn">
+                    <span><?= $block->escapeHtml(__('Clear')) ?></span>
+                </button>
+            </div>
             <label for="attributeGrid_page-limit"></label><select name="limit" id="attributeGrid_page-limit" class="admin__control-select attribute-pager-limit">
                 <?php foreach ($block->getLimits() as $limit): ?>
                     <option value="<?= $limit; ?>" <?= $pagination['pageSize'] === $limit ? 'selected="selected"' : ''; ?>><?= $limit; ?></option>
@@ -146,6 +160,7 @@ $pagination = $block->getPaginationData();
                     "panelType": "visual",
                     "containerSelector": "[data-role=swatch-visual-options-container]",
                     "registryKey": "swatch-visual-options-panel",
+                    "filterSelector": ".attribute-pager-filter-input",
                     "requestParams": <?= /* @noEscape */ json_encode($block->getPagerRequestParams(), JSON_HEX_QUOT) ?>,
                     "pagination": <?= /* @noEscape */ json_encode($pagination, JSON_HEX_QUOT) ?>
                 }

--- a/view/adminhtml/templates/catalog/product/attribute/visual.phtml
+++ b/view/adminhtml/templates/catalog/product/attribute/visual.phtml
@@ -14,6 +14,7 @@
 /** @var $block \Qoliber\AttributeOptionPager\Block\Adminhtml\Attribute\Edit\Options\Text */
 
 $stores = $block->getStoresSortedBySortOrder();
+$pagination = $block->getPaginationData();
 ?>
 <fieldset class="admin__fieldset fieldset">
     <legend class="legend">
@@ -23,22 +24,20 @@ $stores = $block->getStoresSortedBySortOrder();
         <div class="admin__data-grid-pager-wrap attribute-pager">
             <label for="attributeGrid_page-limit"></label><select name="limit" id="attributeGrid_page-limit" class="admin__control-select attribute-pager-limit">
                 <?php foreach ($block->getLimits() as $limit): ?>
-                    <option value="<?= $limit;?>" <?= $block->getCurrentPageSize() === $limit ? 'selected="selected"' : '';?> data-url="<?= $block->getNextUrl($limit , $block->getCurrentPageNumber()); ?>"><?= $limit; ?></option>
+                    <option value="<?= $limit; ?>" <?= $pagination['pageSize'] === $limit ? 'selected="selected"' : ''; ?>><?= $limit; ?></option>
                 <?php endforeach; ?>
             </select>
             <label for="attributeGridattributeGrid_page-limit" class="admin__control-support-text"><?= __('per page'); ?></label>
 
             <div class="admin__data-grid-pager">
-                <button type="button" class="attribute-pager-btn action-previous <?= $block->getCurrentPageNumber() === 1 ? 'disabled' :
-                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() - 1); ?>">
+                <button type="button" class="attribute-pager-btn action-previous<?= $pagination['currentPage'] === 1 ? ' disabled' : '' ?>" data-page="<?= max(1, $pagination['currentPage'] - 1) ?>">
                     <span><?= __('Previous page'); ?></span>
                 </button>
-                <input type="number" id="attributeGrid_page-current" min="1" max="<?= $block->getMaxPageCount() ?>" name="page" value="<?= $block->getCurrentPageNumber(); ?>"
-                       data-url="<?= $block->getNextUrl($block->getCurrentPageSize() , 0) ?>" class="admin__control-text attribute-pager-current" data-ui-id="adminhtml-product-attribute-grid-current-page">
+                <input type="number" id="attributeGrid_page-current" min="1" max="<?= $pagination['maxPageCount'] ?>" name="page" value="<?= $pagination['currentPage']; ?>"
+                       class="admin__control-text attribute-pager-current" data-ui-id="adminhtml-product-attribute-grid-current-page">
                 <label class="admin__control-support-text" for="attributeGrid_page-current">
-                    <?= __('of');?> <span> <?= $block->getMaxPageCount(); ?> </span>                        </label>
-                <button type="button" class="attribute-pager-btn action-next <?= $block->getMaxPageCount() === $block->getCurrentPageNumber() ? ' disabled"' :
-                    '" data-url="' . $block->getNextUrl($block->getCurrentPageSize() , $block->getCurrentPageNumber() + 1); ?>">
+                    <?= __('of');?> <span class="attribute-pager-total-pages"><?= $pagination['maxPageCount']; ?></span></label>
+                <button type="button" class="attribute-pager-btn action-next<?= $pagination['maxPageCount'] === $pagination['currentPage'] ? ' disabled' : '' ?>" data-page="<?= min($pagination['maxPageCount'], $pagination['currentPage'] + 1) ?>">
                     <span><?= __('Next page'); ?></span>
                 </button>
             </div>
@@ -142,7 +141,13 @@ $stores = $block->getStoresSortedBySortOrder();
                     "message": "<?= $block->escapeHtml(__("The value of Admin must be unique.")) ?>"
                 },
                 "Qoliber_AttributeOptionPager/js/pager": {
-                    "ajaxUrlValue": {}
+                    "ajaxUrl": "<?= $block->escapeUrl($block->getPagerAjaxUrl()) ?>",
+                    "panelId": "swatch-visual-options-panel",
+                    "panelType": "visual",
+                    "containerSelector": "[data-role=swatch-visual-options-container]",
+                    "registryKey": "swatch-visual-options-panel",
+                    "requestParams": <?= /* @noEscape */ json_encode($block->getPagerRequestParams(), JSON_HEX_QUOT) ?>,
+                    "pagination": <?= /* @noEscape */ json_encode($pagination, JSON_HEX_QUOT) ?>
                 }
             }
         }

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -1,3 +1,18 @@
 .attribute-pager {
     margin-bottom: 18px;
 }
+
+.attribute-pager-bottom {
+    margin-top: 10px;
+}
+
+.attribute-pager-filter {
+    align-items: center;
+    display: inline-flex;
+    gap: 8px;
+    margin-right: 16px;
+}
+
+.attribute-pager-filter-input {
+    min-width: 220px;
+}

--- a/view/adminhtml/web/js/pager.js
+++ b/view/adminhtml/web/js/pager.js
@@ -1,37 +1,184 @@
 define([
-    'jquery'
-], function ($) {
+    'jquery',
+    'uiRegistry'
+], function ($, registry) {
     "use strict";
+
+    function getPanel(config) {
+        return $('#' + config.panelId);
+    }
+
+    function getCurrentLimit($panel, config) {
+        return parseInt($panel.find('.attribute-pager-limit').first().val(), 10) || config.pagination.pageSize;
+    }
+
+    function getCurrentFilter($panel, config) {
+        var $filter = config.filterSelector ? $panel.find(config.filterSelector).first() : $();
+
+        if (!$filter.length) {
+            return config.requestParams.option_filter || '';
+        }
+
+        return $.trim($filter.val());
+    }
+
+    function updatePagination($panel, pagination) {
+        var previousPage = Math.max(1, pagination.currentPage - 1),
+            nextPage = Math.min(pagination.maxPageCount, pagination.currentPage + 1),
+            isFirstPage = pagination.currentPage <= 1,
+            isLastPage = pagination.currentPage >= pagination.maxPageCount;
+
+        $panel.find('.attribute-pager-limit').val(String(pagination.pageSize));
+        $panel.find('.attribute-pager-current')
+            .val(pagination.currentPage)
+            .attr('max', pagination.maxPageCount);
+        $panel.find('.attribute-pager-total-pages').text(pagination.maxPageCount);
+        $panel.find('.action-previous')
+            .data('page', previousPage)
+            .toggleClass('disabled', isFirstPage)
+            .prop('disabled', isFirstPage);
+        $panel.find('.action-next')
+            .data('page', nextPage)
+            .toggleClass('disabled', isLastPage)
+            .prop('disabled', isLastPage);
+    }
+
+    function resetComponent(component, $panel, config) {
+        component.itemCount = 0;
+        component.totalItems = 0;
+        component.rendered = 0;
+        component.elements = '';
+        $panel.find(config.containerSelector).empty();
+
+        if (typeof component.updateItemsCountField === 'function') {
+            component.updateItemsCountField();
+        }
+    }
+
+    function renderPage(config, attributesData) {
+        var $panel = getPanel(config);
+
+        registry.get(config.registryKey, function (component) {
+            if (typeof component.ignoreValidate === 'function') {
+                component.ignoreValidate();
+            }
+
+            resetComponent(component, $panel, config);
+            component.renderWithDelay(attributesData || [], 0, 100, 300);
+        });
+    }
+
+    function loadPage(config, page, limit) {
+        var $panel = getPanel(config),
+            currentFilter = getCurrentFilter($panel, config),
+            requestData = $.extend({}, config.requestParams, {
+                isAjax: 1,
+                panel: config.panelType,
+                page: page,
+                limit: limit,
+                option_filter: currentFilter
+            }),
+            state = $panel.data('attributePagerState') || {},
+            requestId,
+            renderTriggered = false;
+
+        if (!$panel.length) {
+            return;
+        }
+
+        if (state.request && state.request.readyState !== 4) {
+            state.request.abort();
+        }
+
+        state.requestCounter = (state.requestCounter || 0) + 1;
+        requestId = state.requestCounter;
+        config.requestParams.option_filter = currentFilter;
+        $('body').trigger('processStart');
+
+        state.request = $.ajax({
+            url: config.ajaxUrl,
+            type: 'GET',
+            dataType: 'json',
+            data: requestData
+        }).done(function (response) {
+            if (!response || response.error) {
+                return;
+            }
+
+            config.pagination = response.pagination || config.pagination;
+            updatePagination($panel, config.pagination);
+            renderTriggered = true;
+            renderPage(config, response.attributesData);
+
+            if (response.currentUrl && window.history && typeof window.history.replaceState === 'function') {
+                window.history.replaceState({}, '', response.currentUrl);
+            }
+        }).always(function () {
+            if (state.requestCounter === requestId && !renderTriggered) {
+                $('body').trigger('processStop');
+            }
+        });
+
+        $panel.data('attributePagerState', state);
+    }
+
     return function (config) {
-        $(".attribute-pager-limit").on('change', function () {
-            let option = $(this).find("option:selected");
-            let redirect = $(option).data('url');
-            if (redirect !== undefined) {
-                window.location.href = redirect;
+        var $panel = getPanel(config);
+
+        if (!$panel.length || $panel.data('attributePagerInitialized')) {
+            return;
+        }
+
+        $panel.data('attributePagerInitialized', true);
+        updatePagination($panel, config.pagination);
+
+        $panel.on('change.attributePager', '.attribute-pager-limit', function () {
+            loadPage(config, parseInt($panel.find('.attribute-pager-current').first().val(), 10) || 1, getCurrentLimit($panel, config));
+        });
+
+        $panel.on('blur.attributePager', '.attribute-pager-current', function () {
+            var page = parseInt($(this).val(), 10) || 1,
+                maxPageCount = parseInt($(this).attr('max'), 10) || config.pagination.maxPageCount;
+
+            page = Math.max(1, Math.min(page, maxPageCount));
+            loadPage(config, page, getCurrentLimit($panel, config));
+        });
+
+        $panel.on('keydown.attributePager', '.attribute-pager-current', function (event) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                $(this).trigger('blur');
             }
         });
 
-        $(".attribute-pager-current").on('blur', function () {
-            let page = $(this).val();
-            if (page < $(this).attr('min')) {
-                page = $(this).attr('min');
+        $panel.on('click.attributePager', '.attribute-pager-btn', function () {
+            if ($(this).hasClass('disabled') || $(this).prop('disabled')) {
+                return;
             }
-            if (page > $(this).attr('max')) {
-                page = $(this).attr('max');
-            }
-            let redirect = $(this).data('url').replace('page/0', 'page/' + page)
-            if (redirect !== undefined && redirect != window.location.href) {
-                window.location.href = redirect;
-            }
+
+            loadPage(config, parseInt($(this).data('page'), 10) || 1, getCurrentLimit($panel, config));
         });
 
-        $('.attribute-pager-btn').on('click', function() {
-            let redirect = $(this).data('url');
-            console.log(redirect);
-            if (redirect !== undefined) {
-                window.location.href = redirect;
+        $panel.on('click.attributePager', '.attribute-pager-filter-btn', function () {
+            loadPage(config, 1, getCurrentLimit($panel, config));
+        });
+
+        $panel.on('click.attributePager', '.attribute-pager-filter-clear-btn', function () {
+            var $filter = config.filterSelector ? $panel.find(config.filterSelector).first() : $();
+
+            if ($filter.length) {
+                $filter.val('');
+            }
+
+            config.requestParams.option_filter = '';
+            loadPage(config, 1, getCurrentLimit($panel, config));
+        });
+
+        $panel.on('keydown.attributePager', '.attribute-pager-filter-input', function (event) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                loadPage(config, 1, getCurrentLimit($panel, config));
             }
         });
     };
 });
-


### PR DESCRIPTION
- The module now renders pagination both above and below the standard attribute options table in options.phtml
- Pagination was converted from full-page redirects to AJAX across the attribute option editors, using a new admin JSON endpoint in Controller/Adminhtml/Pager/Options.php, route registration in routes.xml, shared paging/filter helpers in PaginationTrait.php, and client-side refresh logic in pager.js. 
- Implemented an AJAX filter in the top pager only, plus a Clear button.
- Added a full page loader by using global processStart/processStop in pager.js.


